### PR TITLE
GoogleApiService Refactor

### DIFF
--- a/app/controllers/api/v1/antipode_controller.rb
+++ b/app/controllers/api/v1/antipode_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::AntipodeController < ApplicationController
   def index
-    google = GoogleApiService.new
-    amypode = AmypodeApiService.new(google.latitude({address: search_location}), google.longitude({address: search_location}))
-    antipode_city = google.get_city({ latlng: "#{amypode.lat},#{amypode.long}" })
+    geocoding = GoogleApiService.new({address: search_location})
+    amypode = AmypodeApiService.new(geocoding.latitude, geocoding.longitude)
+    antipode_city = GoogleApiService.new({ latlng: "#{amypode.lat},#{amypode.long}" })
     darksky = DarkskyApiService.new(amypode.lat, amypode.long)
     antipode = AntipodeFacade.new(search_location, antipode_city, darksky.response)
     render json: AntipodeSerializer.new(antipode)

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::ForecastController < ApplicationController
   def index
     google = GoogleApiService.new({address: location_params})
-    binding.pry
     darksky = DarkskyApiService.new(google.latitude, google.longitude)
     full_forecast = ForecastFacade.new(google.country_location, darksky.response)
     render json: ForecastSerializer.new(full_forecast)

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,8 +1,9 @@
 class Api::V1::ForecastController < ApplicationController
   def index
-    google = GoogleApiService.new
-    darksky = DarkskyApiService.new(google.latitude({address: location_params}), google.longitude({address: location_params}))
-    full_forecast = ForecastFacade.new(google.country_location({address: location_params}), darksky.response)
+    google = GoogleApiService.new({address: location_params})
+    binding.pry
+    darksky = DarkskyApiService.new(google.latitude, google.longitude)
+    full_forecast = ForecastFacade.new(google.country_location, darksky.response)
     render json: ForecastSerializer.new(full_forecast)
   end
 

--- a/app/facades/antipode_facade.rb
+++ b/app/facades/antipode_facade.rb
@@ -4,7 +4,7 @@ class AntipodeFacade
   def initialize(search, antipode, forecast)
     @id = 11
     @type = 'antipode'
-    @location_name = antipode[:results][0][:address_components][2][:long_name]
+    @location_name = antipode.location[:results][0][:address_components][2][:long_name]
     @forecast = AntipodeForecast.new(forecast)
     @search_location = search[:location]
   end

--- a/app/services/amypode_api_service.rb
+++ b/app/services/amypode_api_service.rb
@@ -4,11 +4,6 @@ class AmypodeApiService
     @longitude = longitude
   end
 
-  def get_antipode
-    response = connection.get('/api/v1/antipodes')
-    JSON.parse(response.body, symbolize_names: true)
-  end
-
   def lat
     get_antipode[:data][:attributes][:lat]
   end
@@ -18,6 +13,10 @@ class AmypodeApiService
   end
 
   private
+  def get_antipode
+    response = connection.get('/api/v1/antipodes')
+    JSON.parse(response.body, symbolize_names: true)
+  end
 
   def connection
     Faraday.new(

--- a/app/services/google_api_service.rb
+++ b/app/services/google_api_service.rb
@@ -1,10 +1,11 @@
 class GoogleApiService
+  attr_reader :location
+  
   def initialize(location)
     @location = get_json(location)
   end
 
   def latitude
-    binding.pry
     @location[:results][0][:geometry][:location][:lat]
   end
 

--- a/app/services/google_api_service.rb
+++ b/app/services/google_api_service.rb
@@ -1,18 +1,19 @@
 class GoogleApiService
-  def latitude(location)
-    get_json(location)[:results][0][:geometry][:location][:lat]
+  def initialize(location)
+    @location = get_json(location)
   end
 
-  def longitude(location)
-    get_json(location)[:results][0][:geometry][:location][:lng]
+  def latitude
+    binding.pry
+    @location[:results][0][:geometry][:location][:lat]
   end
 
-  def country_location(location)
-    get_json(location)[:results][0][:formatted_address]
+  def longitude
+    @location[:results][0][:geometry][:location][:lng]
   end
 
-  def get_city(location)
-    get_json(location)
+  def country_location
+    @location[:results][0][:formatted_address]
   end
 
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -9,3 +9,8 @@
 # production:
 #   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
 #   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
+GOOGLE_API_KEY: AIzaSyAEls9ZDdlcmVmwbAoBjBYHNzZRbzySs0o
+DARKSKY_API_KEY: 4bec3a2817f2cb12f43ff6a566f85bbd
+AMYPODE_API_KEY: oscar_the_grouch
+UNSPLASH_ACCESS_KEY: 2d9f58b410a1a64100360fbe36f74eb4ad3c3f59a5ee49b0330999633ef793e7
+UNSPLASH_SECRET_KEY: 0cf26d6c9beca0a1b9bb5303b3f8689d7dfa15fb48863a5ff6f4c5b8a0443904


### PR DESCRIPTION
Refactor to reduce the amount of API calls going out to Google
* Initialize a GoogleApiService object with the api call instead of running it each time an attribute/method is needed from Google's data
* All tests still passing